### PR TITLE
Fix notecount display

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1713,7 +1713,7 @@ const openBMS = (bmsSource) => {
     genre: headers.genre,
     keys: parseInt(tempParam.keys) || 7,
     lnmap: {},
-    notes: objects.length,
+    notes: objects.filter(x => x.channel.match(/[12][1-9]/) && x.value !== lnobj).length + objects.filter(x => lntype === "1" && x.channel.match(/[56][1-9]/)).length / 2,
     score: [...Array(objects.slice(-1)[0].measure + 1).keys()].map(() => {
       return { length: 72 }
     }),


### PR DESCRIPTION
Hello, thank you very much for your work!

This is a quick PR to fix the notecount display on the BMS chart viewer. The following PR should work with regular notes as well as LNs (both LNOBJ and LNTYPE 1). It filters the `objects` array by only keeping playable channels (11-19 (1P), 21-29 (2P), 51-59 (LN 1P) and 61-69 (LN 2P)) before calculating the length.